### PR TITLE
[FIX] Investigate missing 7 tables (132 vs 139) (#31)

### DIFF
--- a/src/core/etl_phases/validation.py
+++ b/src/core/etl_phases/validation.py
@@ -212,7 +212,14 @@ def validate_all(output_dir=None, valid_tracking_games=None, log=None):
     # Summary
     log.section("VALIDATION SUMMARY")
 
-    total_rows = sum(len(pd.read_csv(f, dtype=str)) for f in output_dir.glob("*.csv"))
+    # Count rows safely, handling empty files
+    def safe_row_count(filepath):
+        try:
+            return len(pd.read_csv(filepath, dtype=str))
+        except pd.errors.EmptyDataError:
+            return 0
+
+    total_rows = sum(safe_row_count(f) for f in output_dir.glob("*.csv"))
     table_count = len(list(output_dir.glob("*.csv")))
 
     log.info(f"Tables: {table_count}")

--- a/src/formulas/player_stats_formulas.py
+++ b/src/formulas/player_stats_formulas.py
@@ -250,8 +250,8 @@ PLAYER_STATS_FORMULAS = {
     'possession_time_defensive_zone_per_60': {
         'type': 'rate',
         'function': lambda df: pd.Series([
-            (pd / 60.0 / toi * 60.0) if pd.notna(toi) and toi > 0 else 0.0
-            for pd, toi in zip(df.get('possession_time_defensive_zone', pd.Series([0]*len(df))), df['toi_minutes'])
+            (poss_def / 60.0 / toi * 60.0) if pd.notna(toi) and toi > 0 else 0.0
+            for poss_def, toi in zip(df.get('possession_time_defensive_zone', pd.Series([0]*len(df))), df['toi_minutes'])
         ]),
         'description': 'Possession time in defensive zone per 60 minutes (minutes)',
         'dependencies': ['possession_time_defensive_zone', 'toi_minutes'],


### PR DESCRIPTION
## Summary

Investigation into why ETL produces 132 tables instead of the documented 139. Identified root causes and applied partial fixes.

## Findings

- **10 tables** defined in code but not being created
- **Root cause:** ETL phases after base_etl fail due to empty file handling errors
- **Documentation discrepancy:** CLAUDE.md says 139, run_etl.py says 128, actual is 132

## Changes Made

- `validation.py`: Handle empty CSV files gracefully with `safe_row_count()`
- `player_stats_formulas.py`: Fix variable `pd` shadowing pandas import

## Missing Tables Identified

- fact_player_game_stats, fact_team_game_stats, fact_goalie_game_stats
- fact_goalie_season_stats, fact_goalie_career_stats (+ basic variants)
- fact_player_season_stats_basic, fact_player_career_stats_basic, fact_team_season_stats_basic

## Follow-up

Created #52 for remaining ETL stability work to generate all missing tables.

## Testing Performed

- [x] ETL runs further than before (validation no longer crashes on empty CSVs)
- [x] Formula bug fixed (variable rename)

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to gracefully manage empty CSV files during data validation.

* **Refactor**
  * Improved code clarity in player statistics calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->