### PR TITLE
[CHORE] Fix P2 documentation issues (#70, #71)

### DIFF
--- a/.agents/core.md
+++ b/.agents/core.md
@@ -10,7 +10,7 @@ Last Updated: 2026-01-21
 
 BenchSight is a comprehensive hockey analytics platform for the NORAD Recreational League. The project consists of:
 
-- **ETL Pipeline** (Python): Processes game data and generates 139 tables
+- **ETL Pipeline** (Python): Processes game data and generates 145 tables
 - **Dashboard** (Next.js 14, TypeScript): Public-facing analytics dashboard
 - **Tracker** (HTML/JS → Rust/Next.js): Game tracking application
 - **Portal** (Next.js): Admin interface for ETL management

--- a/.claude/agents/AGENTS_GUIDE.md
+++ b/.claude/agents/AGENTS_GUIDE.md
@@ -218,7 +218,7 @@
 - Documenting calculation flows
 
 **Example prompts:**
-```
+```text
 "Document fact_line_combinations in the data dictionary"
 "Where does the xg column come from?"
 "Update the ERD with new relationships"

--- a/.claude/agents/hockey-analytics-sme.md
+++ b/.claude/agents/hockey-analytics-sme.md
@@ -114,7 +114,7 @@ When invoked for hockey analytics questions, use this interactive format:
 ### Follow-Up Menu
 
 After answering, offer:
-```
+```text
 Would you like me to:
 - [D]eeper dive on this topic?
 - [S]how related metrics/calculations?

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -525,7 +525,7 @@ After `/pm`:
 
 Ask PM questions about workflow, process, or priorities:
 
-```
+```bash
 /pm ask "Should I create a PRD for this?"
 /pm ask "Is this ready for PR?"
 /pm ask "Should I work on issue A or B first?"
@@ -545,7 +545,7 @@ Ask PM questions about workflow, process, or priorities:
 ### Follow-Up Menu
 
 After answering, offer:
-```
+```text
 Would you like me to:
 - [E]xplain the reasoning further?
 - [S]how related documentation?
@@ -563,7 +563,7 @@ Enter choice:
 PM decisions are logged to the unified issue log:
 
 ### Log Location
-```
+```text
 logs/issues/detected.jsonl   # All detected issues + PM decisions
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ When extracting functions to separate modules:
 - **Entry point:** `run_etl.py`
 - **Core engine:** `src/core/base_etl.py` (~1,065 lines) + `src/core/etl_phases/` modules
 - **Phase-based processing:** Loading → Event/Shift Building → Calculations → Advanced Analytics → Table Generation → QA
-- **Output:** 139 tables (50 dimensions, 81 facts, 8 QA) as CSVs in `data/output/`
+- **Output:** 145 tables (50 dimensions, 87 facts, 8 QA) as CSVs in `data/output/`
 
 ### Dashboard
 - **Framework:** Next.js 14 (App Router) with TypeScript strict mode

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ BenchSight is a comprehensive hockey analytics platform that processes game data
 
 ### Components
 
-- **ETL Pipeline** - Processes game data and generates 139 tables
+- **ETL Pipeline** - Processes game data and generates 145 tables
 - **Dashboard** - Public-facing analytics dashboard (50+ pages)
 - **Tracker** - Game tracking application (HTML/JS → Rust/Next.js)
 - **Portal** - Admin interface for ETL management
@@ -229,7 +229,7 @@ benchsight/
 
 ### ETL Pipeline
 
-- ✅ 139 tables generated (dimensions, facts, QA)
+- ✅ 145 tables generated (dimensions, facts, QA)
 - ✅ Comprehensive stats (317 columns for players, 128 for goalies)
 - ✅ Advanced metrics (Corsi, Fenwick, xG, WAR/GAR, QoC/QoT)
 - ✅ Data validation framework


### PR DESCRIPTION
## Summary
- Add language specifiers to markdown code blocks in .claude/ files (#70)
- Update stale "139 tables" references to "145 tables" in key docs (#71)

## Changes
**#70 - Code block language specifiers:**
- `.claude/agents/hockey-analytics-sme.md` - Added `text` specifier
- `.claude/skills/pm/SKILL.md` - Added `bash` and `text` specifiers
- `.claude/agents/AGENTS_GUIDE.md` - Added `text` specifier

**#71 - Table count updates:**
- `README.md` - Updated 2 references
- `CLAUDE.md` - Updated 1 reference (also corrected fact count to 87)
- `.agents/core.md` - Updated 1 reference

## Test plan
- [x] Markdown renders correctly
- [x] No broken links
- [x] Accurate table count (145 = 50 dim + 87 fact + 8 QA)

## Related Issues
- #70
- #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added formula management system feature to ETL Pipeline.
  * Added API component documentation.

* **Documentation**
  * Updated ETL Pipeline table generation from 139 to 145 tables.
  * Enhanced agent and skill guide documentation with improved formatting and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->