### PR TITLE
[FIX] CI: Remove continue-on-error from validation step (#63)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,7 @@ jobs:
           pip install -r requirements.txt
       
       - name: Run ETL validation
-        run: |
-          python validate.py --quick || echo "Validation check completed"
-        continue-on-error: true
+        run: python validate.py --manifest
       
       - name: Check Python code quality
         run: |


### PR DESCRIPTION
## Summary
Remove `continue-on-error: true` from CI validation step so validation failures actually block PRs.

## Changes
- Remove `continue-on-error: true` from ETL validation step
- Change from `--quick` to `--manifest` for comprehensive table verification  
- Remove `|| echo` fallback that masked failures

## Before
```yaml
- name: Run ETL validation
  run: |
    python validate.py --quick || echo "Validation check completed"
  continue-on-error: true
```

## After
```yaml
- name: Run ETL validation
  run: python validate.py --manifest
```

## Impact
- Validation failures will now properly fail the CI build
- The table verification framework (#35) will actually protect against regressions
- PRs with data quality issues will be blocked

## Test plan
- [x] CI workflow syntax is valid
- [ ] CI runs validation and fails on errors (will verify on this PR)

## Related Issues
- Fixes #63
- Depends on #35 (table verification framework - already merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal validation workflow to enforce stricter error handling during automated checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->