### PR TITLE
[REFACTOR] Add BENCHSIGHT_ENV support for multi-environment config (#74)

### DIFF
--- a/src/core/table_writer.py
+++ b/src/core/table_writer.py
@@ -49,23 +49,22 @@ _uploaded_tables = set()
 def enable_supabase() -> bool:
     """
     Enable direct Supabase upload.
-    
+
     Call this BEFORE running ETL to enable uploads.
+    Uses centralized config_loader for environment-aware config.
     """
     global _supabase_enabled, _supabase_client
-    
-    config_path = Path("config/config_local.ini")
-    
-    if not config_path.exists():
-        log.error(f"Supabase config not found: {config_path}")
-        return False
-    
-    config = configparser.ConfigParser()
-    config.read(config_path)
-    
+
     try:
-        url = config.get('supabase', 'url')
-        key = config.get('supabase', 'service_key')
+        from config.config_loader import load_config
+        cfg = load_config()
+
+        if not cfg.supabase_url or not cfg.supabase_service_key:
+            log.error("Supabase credentials not configured. Set BENCHSIGHT_ENV or create config_local.ini")
+            return False
+
+        url = cfg.supabase_url
+        key = cfg.supabase_service_key
         
         from supabase import create_client
         _supabase_client = create_client(url, key)

--- a/src/supabase/add_game.py
+++ b/src/supabase/add_game.py
@@ -20,14 +20,14 @@ except ImportError:
     print("Install supabase: pip3 install supabase")
     sys.exit(1)
 
-# Config
-# Load from config
-import configparser
+# Config - use centralized config_loader for environment-aware config
 from pathlib import Path
-_config = configparser.ConfigParser()
-_config.read(Path(__file__).parent.parent.parent / "config" / "config_local.ini")
-SUPABASE_URL = _config.get("supabase", "url", fallback="https://uuaowslhpgyiudmbvqze.supabase.co")
-SUPABASE_KEY = _config.get("supabase", "service_key", fallback="")
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+from config.config_loader import load_config
+
+_cfg = load_config()
+SUPABASE_URL = _cfg.supabase_url
+SUPABASE_KEY = _cfg.supabase_service_key
 BLB_FILE = "data/raw/BLB_Tables.xlsx"
 GAMES_DIR = "data/raw/games"
 

--- a/src/supabase/supabase_manager.py
+++ b/src/supabase/supabase_manager.py
@@ -38,38 +38,30 @@ logger = logging.getLogger('SupabaseManager')
 class SupabaseManager:
     """
     Manages all Supabase operations for BenchSight.
-    
-    Reads configuration from config/config_local.ini.
+
+    Reads configuration via config_loader (supports BENCHSIGHT_ENV).
     """
-    
+
     # Tables to skip (system tables, etc.)
     SKIP_TABLES = {'VERSION', 'TABLE_MANIFEST'}
-    
+
     # Batch size for uploads
     BATCH_SIZE = 500
-    
+
     def __init__(self, config_path: Optional[Path] = None):
         """
         Initialize Supabase manager.
-        
+
         Args:
-            config_path: Path to config file (default: config/config_local.ini)
+            config_path: Path to config file (optional, uses config_loader by default)
         """
-        # Find config
-        if config_path is None:
-            base_dir = Path(__file__).parent.parent.parent
-            config_path = base_dir / 'config' / 'config_local.ini'
-        
-        if not config_path.exists():
-            raise FileNotFoundError(f"Config not found: {config_path}")
-        
-        # Load config
-        config = configparser.ConfigParser()
-        config.read(config_path)
-        
-        self.url = config.get('supabase', 'url')
-        self.key = config.get('supabase', 'service_key')
-        
+        # Use config_loader for environment-aware config
+        from config.config_loader import load_config
+        cfg = load_config(config_path)
+
+        self.url = cfg.supabase_url
+        self.key = cfg.supabase_service_key
+
         if not self.url or not self.key:
             raise ValueError("Supabase URL and service_key required in config")
         

--- a/tests/test_supabase_config.py
+++ b/tests/test_supabase_config.py
@@ -17,42 +17,46 @@ SQL_DIR = Path("sql")
 
 
 class TestSupabaseConfiguration:
-    """Test Supabase configuration files."""
-    
-    def test_config_local_ini_exists(self):
-        """Verify config_local.ini exists."""
-        config_file = CONFIG_DIR / "config_local.ini"
-        assert config_file.exists(), "config_local.ini not found"
-    
-    def test_config_has_supabase_section(self):
-        """Verify config has [supabase] section."""
-        config_file = CONFIG_DIR / "config_local.ini"
-        if config_file.exists():
-            config = configparser.ConfigParser()
-            config.read(config_file)
-            assert 'supabase' in config.sections(), "Missing [supabase] section"
-    
-    def test_config_has_url(self):
+    """Test Supabase configuration using centralized config_loader."""
+
+    def test_config_loader_works(self):
+        """Verify config_loader can load configuration."""
+        import sys
+        sys.path.insert(0, str(PROJECT_DIR))
+        from config.config_loader import load_config
+        cfg = load_config()
+        assert cfg is not None, "config_loader returned None"
+
+    def test_config_has_supabase_url(self):
         """Verify config has Supabase URL."""
-        config_file = CONFIG_DIR / "config_local.ini"
-        if config_file.exists():
-            config = configparser.ConfigParser()
-            config.read(config_file)
-            if 'supabase' in config.sections():
-                url = config.get('supabase', 'url', fallback=None)
-                assert url is not None, "Missing supabase url"
-                assert 'supabase.co' in url, "URL doesn't look like Supabase"
-    
-    def test_config_has_key(self):
-        """Verify config has Supabase key."""
-        config_file = CONFIG_DIR / "config_local.ini"
-        if config_file.exists():
-            config = configparser.ConfigParser()
-            config.read(config_file)
-            if 'supabase' in config.sections():
-                key = config.get('supabase', 'key', fallback=None)
-                assert key is not None, "Missing supabase key"
-                assert len(key) > 50, "Key seems too short"
+        import sys
+        sys.path.insert(0, str(PROJECT_DIR))
+        from config.config_loader import load_config
+        cfg = load_config()
+        # URL should be set via BENCHSIGHT_ENV or config_local.ini
+        if cfg.supabase_url:
+            assert 'supabase.co' in cfg.supabase_url, "URL doesn't look like Supabase"
+
+    def test_config_has_service_key(self):
+        """Verify config has Supabase service key."""
+        import sys
+        sys.path.insert(0, str(PROJECT_DIR))
+        from config.config_loader import load_config
+        cfg = load_config()
+        # Key should be set via BENCHSIGHT_ENV or config_local.ini
+        if cfg.supabase_service_key:
+            assert len(cfg.supabase_service_key) > 50, "Key seems too short"
+
+    def test_config_validates(self):
+        """Verify config validation works."""
+        import sys
+        sys.path.insert(0, str(PROJECT_DIR))
+        from config.config_loader import load_config
+        cfg = load_config()
+        valid, errors = cfg.validate()
+        # Just verify validate() works - actual validity depends on env setup
+        assert isinstance(valid, bool)
+        assert isinstance(errors, list)
 
 
 class TestSupabaseSQLFiles:


### PR DESCRIPTION
## Summary
Refactor hardcoded config paths to use centralized `config_loader`, enabling parallel terminals to target different environments (dev/prod) without conflicts.

## Problem
Multiple files were hardcoded to read from `config/config_local.ini`, making it impossible to run different environments in parallel.

## Changes
| File | Before | After |
|------|--------|-------|
| `src/supabase/add_game.py` | Hardcoded `config_local.ini` | Uses `config_loader` |
| `src/core/table_writer.py` | Hardcoded `config_local.ini` | Uses `config_loader` |
| `scripts/deploy_views.py` | Hardcoded `CONFIG_FILE` | Uses `config_loader` |
| `src/supabase/supabase_manager.py` | Already updated | Uses `config_loader` |
| `tests/test_supabase_config.py` | Hardcoded tests | Uses `config_loader` |

## Usage After This PR
```bash
# Terminal 1 - Dev work
export BENCHSIGHT_ENV=dev
./benchsight.sh etl run

# Terminal 2 - Prod work (or different dev instance)
export BENCHSIGHT_ENV=prod
./benchsight.sh db upload
```

## Backward Compatibility
- No `BENCHSIGHT_ENV` set → falls back to `config_local.ini` (current behavior)
- Existing scripts continue to work unchanged

## Test plan
- [x] Files refactored to use config_loader
- [x] Tests updated to use config_loader
- [ ] Manual test: `BENCHSIGHT_ENV=dev python -c "from config.config_loader import load_config; print(load_config().supabase_url)"`

## Related Issues
- Fixes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Configuration management refactored to use a centralized, environment-aware loader instead of local INI files across the application
  * Configuration loading now validates Supabase credentials through the centralized system
  * Enhanced error handling with improved logging for configuration load failures
  * Updated configuration test suite to validate the new centralized approach and configuration object validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->