### PR TITLE
[FIX] Fix ExportButton property names in faceoffs page

### DIFF
--- a/ui/dashboard/src/app/norad/(dashboard)/analytics/faceoffs/page.tsx
+++ b/ui/dashboard/src/app/norad/(dashboard)/analytics/faceoffs/page.tsx
@@ -311,18 +311,18 @@ export default async function FaceoffAnalysisPage() {
             <BarChart3 className="w-4 h-4" />
             Comprehensive Faceoff Statistics
           </h2>
-          <ExportButton 
+          <ExportButton
             data={statsWithPlayers
               .filter(p => p.foTotal > 0)
               .map(f => ({
-                Player: f.playerName,
-                Team: f.teamName,
+                Player: f.player_name || f.player?.player_full_name || 'Unknown',
+                Team: f.team?.team_name || '',
                 GP: f.games,
-                Wins: f.totalWins,
-                Losses: f.totalLosses,
+                Wins: f.foWins,
+                Losses: f.foLosses,
                 Total: f.foTotal,
-                'Win %': f.winPct.toFixed(1) + '%',
-                'Avg/G': f.avgPerGame.toFixed(1),
+                'Win %': f.foPct.toFixed(1) + '%',
+                'Avg/G': f.foTotalPerGame.toFixed(1),
               }))}
             filename="faceoff_stats"
           />


### PR DESCRIPTION
## Summary
- Fixed 500 error on `/norad/analytics/faceoffs` page caused by incorrect property names in ExportButton data mapping

## Changes
The ExportButton component was referencing non-existent properties:
- `playerName` → `player_name`
- `teamName` → `team?.team_name`
- `totalWins` → `foWins`
- `totalLosses` → `foLosses`
- `winPct` → `foPct`
- `avgPerGame` → `foTotalPerGame`

## Test Plan
- [x] Verified page returns 200 after fix
- [x] All 46 dashboard pages tested and passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated faceoff statistics export to display accurate faceoff-specific metrics (wins, losses, percentages, and totals per game) instead of general game statistics.
  * Improved data accuracy by properly deriving player and team information from source data with appropriate fallbacks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->