### PR TITLE
[FEAT] Add running_video_time to fact_shifts (#136)

### DIFF
--- a/src/builders/shifts.py
+++ b/src/builders/shifts.py
@@ -45,7 +45,10 @@ def build_fact_shifts(
         'home_team_pk', 'home_team_pp', 'away_team_pp', 'away_team_pk',
         'situation', 'strength', 'home_goals', 'away_goals',
         'stoppage_time', 'home_ozone_start', 'home_ozone_end',
-        'home_dzone_start', 'home_dzone_end', 'home_nzone_start', 'home_nzone_end'
+        'home_dzone_start', 'home_dzone_end', 'home_nzone_start', 'home_nzone_end',
+        # Video timing columns (#136)
+        'running_video_time', 'shift_start_running_time', 'shift_end_running_time',
+        'period_start_total_running_seconds'
     ]
     
     shifts = shifts[[c for c in keep_cols if c in shifts.columns]]


### PR DESCRIPTION
## Summary

Adds video timing columns to `fact_shifts` table to enable video deep-linking for shift data.

### Changes

Updated `src/builders/shifts.py` to include these columns from the tracker export:
- `running_video_time` - Primary column for video deep-linking
- `shift_start_running_time` - Running time at shift start
- `shift_end_running_time` - Running time at shift end
- `period_start_total_running_seconds` - Period start reference

### Why

The tracker already exports these columns but they were being filtered out in the ETL. This change preserves them so the dashboard can link shifts to video timestamps, matching the functionality already available for events.

### Verification

```
fact_shifts: min=0, max=3441 (running_video_time)
fact_events: min=-1107, max=3463 (running_video_time)
```

Sample shift data shows correct progression:
- Shift 1: period=1, start=21:00, running_video_time=0
- Shift 2: period=1, start=20:24, running_video_time=36

## Test plan

- [x] Run ETL on game 18969
- [x] Verify `running_video_time` column exists in fact_shifts
- [x] Verify values are populated (437/445 non-null)
- [x] Verify values align with event timing

## Related

- Closes #136
- Unblocks #135 (video deep-links on dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shift data exports now include additional video timing information when available: running video time, shift start and end running times, and period start total running seconds. These additions provide enhanced temporal context for shift analysis and reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->