### PR TITLE
[FIX] Correct EN situation label convention (#177)

### DIFF
--- a/ui/tracker/tracker_index_v29.html
+++ b/ui/tracker/tracker_index_v29.html
@@ -31613,7 +31613,8 @@ function buildExportWorkbook() {
         home_team_pp: (!homeEN && !awayEN && homeSkaters > awaySkaters) ? 1 : 0,
         away_team_pp: (!homeEN && !awayEN && awaySkaters > homeSkaters) ? 1 : 0,
         away_team_pk: (!homeEN && !awayEN && awaySkaters < homeSkaters) ? 1 : 0,
-        situation: (homeEN || awayEN) ? (homeEN ? 'away_en' : 'home_en') : (homeSkaters === awaySkaters) ? 'even' : (homeSkaters > awaySkaters ? 'home_pp' : 'away_pp'),
+        // v29.1: Fix #177 — situation indicates which team HAS the empty net (home_en = home pulled goalie)
+        situation: (homeEN || awayEN) ? (homeEN ? 'home_en' : 'away_en') : (homeSkaters === awaySkaters) ? 'even' : (homeSkaters > awaySkaters ? 'home_pp' : 'away_pp'),
         home_goals: goals.startHome,
         away_goals: goals.startAway,
         // Plus/minus: goals FOR and AGAINST during this shift


### PR DESCRIPTION
## Summary
- Fixed backwards `situation` field in tracker shift export — `home_en`/`away_en` now correctly indicates which team HAS the empty net (pulled their goalie)
- The `strength` field (ENH/ENA) was already corrected in v29.0; this fixes the missed `situation` field

## Changes
- `ui/tracker/tracker_index_v29.html`: Swapped ternary from `homeEN ? 'away_en' : 'home_en'` to `homeEN ? 'home_en' : 'away_en'`

## Test plan
- [ ] Track a shift with home goalie pulled → verify situation=home_en, strength=ENH
- [ ] Track a shift with away goalie pulled → verify situation=away_en, strength=ENA
- [ ] Normal shifts unaffected (situation=even/home_pp/away_pp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Import Value Mappings modal for mapping imported data to database dimensions with fuzzy matching support.
  * Enhanced export functionality now produces multiple data sheets with comprehensive metadata.

* **Improvements**
  * Improved import process with detailed validation for Excel/CSV files, handling multiple data formats and inconsistent naming conventions.
  * Added comprehensive error handling with user-friendly warnings and correction prompts during import/export operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->