### PR TITLE
[FIX] Stop all remaining puckXY auto-population and revert paths

### DIFF
--- a/ui/tracker/tracker_index_v29.html
+++ b/ui/tracker/tracker_index_v29.html
@@ -17072,9 +17072,8 @@ function editAutoEvent() {
     if (pendingAutoEvent.linkedIdx !== null && pendingAutoEvent.linkedIdx !== undefined) {
       S.linkedEventIdx = pendingAutoEvent.linkedIdx;
     }
-    if (pendingAutoEvent.puckXY?.length) {
-      S.curr.puckXY = [...pendingAutoEvent.puckXY];
-    }
+    // v29.1: Do NOT copy puckXY from auto-event — user must click rink
+    // Was causing random puck positions on auto-generated events
     if (pendingAutoEvent.players?.length) {
       S.curr.players = pendingAutoEvent.players.map(p => ({...p}));
       renumberPlayers();
@@ -18801,16 +18800,9 @@ function autoLinkFollowUp(type) {
     // Copy time from shot
     document.getElementById('evtStartTime').value = lastEvt.start_time;
     
-    // Copy puck position from shot
-    if (lastEvt.puckXY?.length) {
-      S.curr.puckXY = lastEvt.puckXY.map(xy => ({...xy}));
-    }
-    
-    // Copy net position from shot
-    if (lastEvt.netXY) {
-      S.curr.netXY = {...lastEvt.netXY};
-    }
-    
+    // v29.1: Do NOT copy puckXY/netXY from shot — user must click rink
+    // Was causing random puck positions on Save after Shot
+
     toast(`Auto-linked to Shot #${lastEvt.idx + 1}`, 'info');
   }
   
@@ -18830,10 +18822,8 @@ function autoLinkFollowUp(type) {
     const linkedEvtEl = document.getElementById('linkedEvt');
     if (linkedEvtEl) linkedEvtEl.value = lastEvt.idx + 1;
     document.getElementById('evtStartTime').value = lastEvt.start_time;
-    // Copy puck XY from previous event
-    if (lastEvt.puckXY?.length) {
-      S.curr.puckXY = lastEvt.puckXY.map(xy => ({...xy}));
-    }
+    // v29.1: Do NOT copy puckXY from previous event — user must click rink
+    // Was causing random puck positions on linked events
     toast(`Auto-linked to ${lastEvt.type} #${lastEvt.idx + 1} (Ctrl+U to unlink)`, 'info');
   }
 }
@@ -22030,8 +22020,10 @@ function saveEventFromSidePanel() {
   evt.detail1 = document.getElementById('evtD1').value || evt.detail1;
   evt.detail2 = document.getElementById('evtD2').value || evt.detail2;
   evt.players = S.curr.players ? S.curr.players.map(p => ({...p, xy: [...(p.xy || [])]})) : evt.players;
-  evt.puckXY = S.curr.puckXY && S.curr.puckXY.length > 0 ? [...S.curr.puckXY] : evt.puckXY;
-  evt.netXY = S.curr.netXY ? {...S.curr.netXY} : evt.netXY;
+  // v29.1: Always use current state — if user cleared XY, save it as cleared
+  // Was falling back to old evt.puckXY causing "revert" behavior
+  evt.puckXY = S.curr.puckXY ? [...S.curr.puckXY] : [];
+  evt.netXY = S.curr.netXY ? {...S.curr.netXY} : null;
   
   // Update type codes and IDs for export
   if (evt.type) {


### PR DESCRIPTION
## Summary
- Removed 3 remaining code paths that auto-injected puck XY coordinates without user action
- Fixed save revert bug where clearing XY and saving would restore old values

## Root Causes
1. `editAutoEvent()` copied cached puckXY from auto-event suggestions
2. `autoLinkFollowUp()` copied puckXY from previous event on every type change (2 paths: Save-after-Shot and generic linked events)
3. `saveEventFromSidePanel()` fell back to old `evt.puckXY` when `S.curr.puckXY` was empty — this was the revert bug

## Fixes
- All three functions no longer copy puck XY automatically
- `saveEventFromSidePanel()` now always saves current state (empty = empty, not fallback to old)
- All puck XY must come from explicit user clicks on the rink

## Test plan
- [ ] Create new event → puck XY should be empty (no random position)
- [ ] Log Shot, then type Save → puck XY should be empty (not copied from shot)
- [ ] Edit an event, clear its puck XY, save → XY should stay cleared (not revert)
- [ ] Click rink to set puck XY → should work normally
- [ ] Auto-chain events (Goal→Stoppage→Faceoff) still log correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced import/export functionality with comprehensive validation for game and roster data (Excel and CSV formats)
  * Auto-mapping and fuzzy matching capabilities for improved data entry
  * Chain templates for common hockey plays
  * Improved modal dialogs and confirmation workflows

* **Improvements**
  * Enhanced error reporting and data validation checks
  * Better user prompts and visual management of operations

* **Refactor**
  * Restructured template and modal systems for improved flexibility and maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->