### PR TITLE
[FIX] Fix dashboard 404 routes (#179)

### DIFF
--- a/ui/dashboard/src/app/norad/(dashboard)/analytics/page.tsx
+++ b/ui/dashboard/src/app/norad/(dashboard)/analytics/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function AnalyticsIndexPage() {
+  redirect('/norad/analytics/overview')
+}

--- a/ui/dashboard/src/components/games/game-media-section.tsx
+++ b/ui/dashboard/src/components/games/game-media-section.tsx
@@ -756,7 +756,7 @@ export function GameMediaSection({
 
                     {/* Player photo */}
                     <Link
-                      href={`/norad/player/${player.player_id}`}
+                      href={`/norad/players/${player.player_id}`}
                       className="flex-shrink-0 hover:opacity-80 transition-opacity"
                     >
                       <PlayerPhoto
@@ -770,7 +770,7 @@ export function GameMediaSection({
                     {/* Player name & team */}
                     <div className="flex-1 min-w-0">
                       <Link
-                        href={`/norad/player/${player.player_id}`}
+                        href={`/norad/players/${player.player_id}`}
                         className="font-display text-sm font-semibold text-foreground hover:text-primary transition-colors block truncate"
                       >
                         {player.player_name}

--- a/ui/dashboard/src/components/games/three-stars.tsx
+++ b/ui/dashboard/src/components/games/three-stars.tsx
@@ -85,7 +85,7 @@ function StarRow({ player, rank }: StarRowProps) {
 
       {/* Player photo */}
       <Link
-        href={`/norad/player/${player.player_id}`}
+        href={`/norad/players/${player.player_id}`}
         className="flex-shrink-0 hover:opacity-80 transition-opacity"
       >
         <PlayerPhoto
@@ -99,7 +99,7 @@ function StarRow({ player, rank }: StarRowProps) {
       {/* Player name & team */}
       <div className="flex-1 min-w-0">
         <Link
-          href={`/norad/player/${player.player_id}`}
+          href={`/norad/players/${player.player_id}`}
           className="font-display text-sm font-semibold text-foreground hover:text-primary transition-colors block truncate"
         >
           {player.player_name}


### PR DESCRIPTION
## Summary
- Added `/norad/analytics` redirect page → forwards to `/norad/analytics/overview`
- Fixed 4 broken player links using singular `/norad/player/` instead of plural `/norad/players/`

## Changes
- **New:** `ui/dashboard/src/app/norad/(dashboard)/analytics/page.tsx` — redirect to overview
- **Fix:** `game-media-section.tsx` — 2 links changed from `/player/` to `/players/`
- **Fix:** `three-stars.tsx` — 2 links changed from `/player/` to `/players/`

## Issue Triage
3 of the 7 originally reported 404s were already fixed (player sub-pages now exist). 1 had no navigation pointing to it. 2 are correct notFound() behavior for invalid IDs. The remaining 2 are fixed in this PR.

## Test plan
- [ ] `/norad/analytics` → redirects to `/norad/analytics/overview`
- [ ] Click player name in game highlights → goes to `/norad/players/{id}` (not 404)
- [ ] Click player name in three-stars → goes to `/norad/players/{id}` (not 404)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics dashboard with automatic redirection to overview section.

* **Bug Fixes**
  * Corrected player profile navigation links to use correct route path across game components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->